### PR TITLE
version pins paramiko to past 2.7, to handle OpenSSH RSA keys

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'argparse==1.4.0',
         'singer-python==5.9.0',
-        'paramiko==2.6.0',
+        'paramiko==2.8.0',
         'backoff==1.8.0',
     ],
     entry_points='''


### PR DESCRIPTION
* Paramiko 2.6 does not handle the case for OpenSSH RSA keys, bumped the version. 